### PR TITLE
Fix <all_urls> permission being an optional and required permission

### DIFF
--- a/background/addon-state.js
+++ b/background/addon-state.js
@@ -30,27 +30,6 @@ class AddonState {
     };
 
     browser.runtime.onMessage.addListener(async (message, {tab}) => {
-      if (message.command === "enableContentScript") {
-        this.enableContentScript(message.value);
-      } else {
-        this.handleColorMessage(message, {tab});
-      }
-    });
-
-    this.enableContentScript = async (value) => {
-      if (value === true) {
-        let file = "data/contentscript.js";
-        this.state.contentScript = await browser.contentScripts.register({
-          matches: ["<all_urls>"],
-          js: [{file}],
-        });
-      } else if (this.state.contentScript !== null) {
-        await this.state.contentScript.unregister();
-        this.state.contentScript = null;
-      }
-    };
-
-    this.handleColorMessage = async (message, {tab}) => {
       let usePageDefinedColors = await Settings.getUsePageDefinedColors();
       let hasPageDefinedColor = false;
 
@@ -77,7 +56,7 @@ class AddonState {
       if (tab.active) {
         onTabColorChange(tab);
       }
-    };
+    });
 
     browser.tabs.onActivated.addListener(async ({ tabId }) => {
       let tab = await browser.tabs.get(tabId);

--- a/background/addon-state.js
+++ b/background/addon-state.js
@@ -31,23 +31,24 @@ class AddonState {
 
     browser.runtime.onMessage.addListener(async (message, {tab}) => {
       if (message.command === "enableContentScript") {
-        this.handleContentScriptMessage(message);
+        this.enableContentScript(message.value);
       } else {
         this.handleColorMessage(message, {tab});
       }
     });
 
-    this.handleContentScriptMessage = async (message) => {
-      if(message.value === true) {
+    this.enableContentScript = async (value) => {
+      if (value === true) {
         let file = "data/contentscript.js";
         this.state.contentScriptObj = await browser.contentScripts.register({
           matches: ["<all_urls>"],
           js: [{file}],
         });
       } else if (this.state.contentScriptObj !== null) {
-        this.state.contentScriptObj.unregister()
+        await this.state.contentScriptObj.unregister();
+        this.state.contentScriptObj = null;
       }
-  };
+    };
 
     this.handleColorMessage = async (message, {tab}) => {
       let usePageDefinedColors = await Settings.getUsePageDefinedColors();

--- a/background/addon-state.js
+++ b/background/addon-state.js
@@ -85,7 +85,7 @@ class AddonState {
       this.state.tabColorMap.delete(tabId));
 
     this.refreshAddon = async () => {
-      onInit(this.state);
+      onInit();
 
       browser.alarms.create(
         "nightToggle", { when: (await firstAlarm()) }
@@ -122,7 +122,7 @@ class AddonState {
         );
       }
     });
-    onInit(this.state);
+    onInit();
   }
 }
 

--- a/background/addon-state.js
+++ b/background/addon-state.js
@@ -12,7 +12,7 @@ class AddonState {
   }) {
     this.state = {
       tabColorMap: new Map(),
-      contentScriptObj: null,
+      contentScript: null,
     };
 
     onTabColorChange = onTabColorChange.bind(this);
@@ -40,13 +40,13 @@ class AddonState {
     this.enableContentScript = async (value) => {
       if (value === true) {
         let file = "data/contentscript.js";
-        this.state.contentScriptObj = await browser.contentScripts.register({
+        this.state.contentScript = await browser.contentScripts.register({
           matches: ["<all_urls>"],
           js: [{file}],
         });
-      } else if (this.state.contentScriptObj !== null) {
-        await this.state.contentScriptObj.unregister();
-        this.state.contentScriptObj = null;
+      } else if (this.state.contentScript !== null) {
+        await this.state.contentScript.unregister();
+        this.state.contentScript = null;
       }
     };
 

--- a/background/background.js
+++ b/background/background.js
@@ -30,7 +30,7 @@ async function isDayMode() {
 }
 
 new AddonState({
-  async onInit() {
+  async onInit(state) {
     let themes = await Settings.getThemes();
 
     let selectedTheme;
@@ -53,6 +53,13 @@ new AddonState({
     }
     if (isFirstRun)
       Settings.setIsFirstRun(false);
+    if (await Settings.getUsePageDefinedColors() && hasAllUrlsPermissions) {
+      let file = "data/contentscript.js";
+      state.contentScriptObj = await browser.contentScripts.register({
+        matches: ["<all_urls>"],
+        js: [{file}],
+      });
+    }
   },
   onTabColorChange(tab) {
     return setColor(tab, this.state.tabColorMap);

--- a/background/background.js
+++ b/background/background.js
@@ -53,7 +53,7 @@ new AddonState({
     }
     if (isFirstRun)
       Settings.setIsFirstRun(false);
-    if (await Settings.getUsePageDefinedColors() && hasAllUrlsPermissions) {
+    if (await Settings.getUsePageDefinedColors() && state.contentScriptObj === null) {
       let file = "data/contentscript.js";
       state.contentScriptObj = await browser.contentScripts.register({
         matches: ["<all_urls>"],

--- a/background/background.js
+++ b/background/background.js
@@ -54,14 +54,14 @@ new AddonState({
     if (isFirstRun)
       Settings.setIsFirstRun(false);
 
-    let usePageDefinedColors = await Settings.getUsePageDefinedColors() ;
-    if (usePageDefinedColors && this.state.contentScript === null) {
-      let file = "data/contentscript.js";
+    let usePageDefinedColors = await Settings.getUsePageDefinedColors();
+    if (usePageDefinedColors && this.state.contentScript) {
+      let file = ;
       this.state.contentScript = await browser.contentScripts.register({
         matches: ["<all_urls>"],
-        js: [{file}],
+        js: [{ file: "data/contentscript.js" }],
       });
-    } else if (!usePageDefinedColors && this.state.contentScript !== null) {
+    } else if (!usePageDefinedColors && !this.state.contentScript) {
       this.state.contentScript.unregister();
       this.state.contentScript = null;
     }

--- a/background/background.js
+++ b/background/background.js
@@ -53,12 +53,17 @@ new AddonState({
     }
     if (isFirstRun)
       Settings.setIsFirstRun(false);
-    if (await Settings.getUsePageDefinedColors() && state.contentScript === null) {
+
+    let usePageDefinedColors = await Settings.getUsePageDefinedColors() ;
+    if (usePageDefinedColors && state.contentScript === null) {
       let file = "data/contentscript.js";
       state.contentScript = await browser.contentScripts.register({
         matches: ["<all_urls>"],
         js: [{file}],
       });
+    } else if (!usePageDefinedColors && state.contentScript !== null) {
+      state.contentScript.unregister();
+      state.contentScript = null;
     }
   },
   onTabColorChange(tab) {

--- a/background/background.js
+++ b/background/background.js
@@ -53,9 +53,9 @@ new AddonState({
     }
     if (isFirstRun)
       Settings.setIsFirstRun(false);
-    if (await Settings.getUsePageDefinedColors() && state.contentScriptObj === null) {
+    if (await Settings.getUsePageDefinedColors() && state.contentScript === null) {
       let file = "data/contentscript.js";
-      state.contentScriptObj = await browser.contentScripts.register({
+      state.contentScript = await browser.contentScripts.register({
         matches: ["<all_urls>"],
         js: [{file}],
       });

--- a/background/background.js
+++ b/background/background.js
@@ -30,7 +30,7 @@ async function isDayMode() {
 }
 
 new AddonState({
-  async onInit(state) {
+  async onInit() {
     let themes = await Settings.getThemes();
 
     let selectedTheme;
@@ -55,15 +55,15 @@ new AddonState({
       Settings.setIsFirstRun(false);
 
     let usePageDefinedColors = await Settings.getUsePageDefinedColors() ;
-    if (usePageDefinedColors && state.contentScript === null) {
+    if (usePageDefinedColors && this.state.contentScript === null) {
       let file = "data/contentscript.js";
-      state.contentScript = await browser.contentScripts.register({
+      this.state.contentScript = await browser.contentScripts.register({
         matches: ["<all_urls>"],
         js: [{file}],
       });
-    } else if (!usePageDefinedColors && state.contentScript !== null) {
-      state.contentScript.unregister();
-      state.contentScript = null;
+    } else if (!usePageDefinedColors && this.state.contentScript !== null) {
+      this.state.contentScript.unregister();
+      this.state.contentScript = null;
     }
   },
   onTabColorChange(tab) {

--- a/manifest.json
+++ b/manifest.json
@@ -27,14 +27,6 @@
   "commands": {
     "_execute_browser_action": {}
   },
-  "content_scripts": [{
-    "matches": [
-      "<all_urls>"
-    ],
-    "js": [
-      "data/contentscript.js"
-    ]
-  }],
   "options_ui": {
     "page": "options/options.html",
     "browser_style": false,

--- a/options/options.js
+++ b/options/options.js
@@ -162,7 +162,7 @@ async function init() {
             target.checked = value;
             browser.runtime.sendMessage({
               command: "enableContentScript",
-              velue: value,
+              value: value,
             });
           } else {
             // Couldn't get permission, need to revert checkbox

--- a/options/options.js
+++ b/options/options.js
@@ -158,12 +158,8 @@ async function init() {
         browser.permissions.request(permissionsToRequest).then((granted) => {
           if (granted) {
             this.state.settings.usePageDefinedColors = value;
-            Settings.setUsePageDefinedColors(value);
             target.checked = value;
-            browser.runtime.sendMessage({
-              command: "enableContentScript",
-              value: value,
-            });
+            Settings.setUsePageDefinedColors(value);
           } else {
             // Couldn't get permission, need to revert checkbox
             target.checked = false;

--- a/options/options.js
+++ b/options/options.js
@@ -160,6 +160,10 @@ async function init() {
             this.state.settings.usePageDefinedColors = value;
             Settings.setUsePageDefinedColors(value);
             target.checked = value;
+            browser.runtime.sendMessage({
+              command: "enableContentScript",
+              velue: value,
+            });
           } else {
             // Couldn't get permission, need to revert checkbox
             target.checked = false;

--- a/welcome/welcome.js
+++ b/welcome/welcome.js
@@ -4,13 +4,7 @@ const ALL_URLS = {
 
 function requestPermissions() {
   browser.permissions.request(ALL_URLS)
-    .then(granted => {
-      browser.runtime.sendMessage({
-        command: "enableContentScript",
-        value: granted,
-      });
-      Settings.setUsePageDefinedColors(granted);
-    });
+    .then(granted => Settings.setUsePageDefinedColors(granted));
 }
 
 document.querySelector("#request-permission").addEventListener("click", requestPermissions);

--- a/welcome/welcome.js
+++ b/welcome/welcome.js
@@ -4,7 +4,13 @@ const ALL_URLS = {
 
 function requestPermissions() {
   browser.permissions.request(ALL_URLS)
-    .then(granted => Settings.setUsePageDefinedColors(granted));
+    .then(granted => {
+      browser.runtime.sendMessage({
+        command: "enableContentScript",
+        value: granted,
+      });
+      Settings.setUsePageDefinedColors(granted);
+    });
 }
 
 document.querySelector("#request-permission").addEventListener("click", requestPermissions);


### PR DESCRIPTION
Hi,
I noticed that now the <all_urls> permission is optional, but also required, because the content_scripts property in the manifest requires it to insert the content script into every page. This pull request registers and unregisters the content script depending on the optional permission.    

I need to save the contentScriptObject in the state of the addon, so I can unregister the content script, when the option is disabled. You could also simplify the code, by just letting the content script stay registered until the browser is relaunched, but I believe that this is the proper way to do it.